### PR TITLE
Fix implicit conversion from uint64_t to size_t.

### DIFF
--- a/src/metrohash128.cpp
+++ b/src/metrohash128.cpp
@@ -72,7 +72,7 @@ void MetroHash128::Update(const uint8_t * const buffer, const uint64_t length)
         if (fill > length)
             fill = length;
 
-        memcpy(input.b + (bytes % 32), ptr, fill);
+        memcpy(input.b + (bytes % 32), ptr, (size_t) fill);
         ptr   += fill;
         bytes += fill;
         

--- a/src/metrohash64.cpp
+++ b/src/metrohash64.cpp
@@ -67,7 +67,7 @@ void MetroHash64::Update(const uint8_t * const buffer, const uint64_t length)
         if (fill > length)
             fill = length;
 
-        memcpy(input.b + (bytes % 32), ptr, fill);
+        memcpy(input.b + (bytes % 32), ptr, (size_t) fill);
         ptr   += fill;
         bytes += fill;
         


### PR DESCRIPTION
When compiling for x86 the conversion from uint64_t to size_t generates a truncation warning, which becomes an error if built with -Werror.