### PR TITLE
don't build/test CRC versions when building for non-x86

### DIFF
--- a/src/metrohash.h
+++ b/src/metrohash.h
@@ -19,6 +19,8 @@
 
 #include "metrohash64.h"
 #include "metrohash128.h"
+#ifdef __x86_64__
 #include "metrohash128crc.h"
+#endif
 
 #endif // #ifndef METROHASH_METROHASH_H

--- a/src/testvector.h
+++ b/src/testvector.h
@@ -22,7 +22,7 @@
 
 typedef void (*HashFunction) (const uint8_t * key, uint64_t len, uint32_t seed, uint8_t * hash);
 
-struct TestVectorData 
+struct TestVectorData
 {
 	HashFunction function;
 	uint32_t bits;
@@ -39,23 +39,27 @@ static const char * test_key_63 = "012345678901234567890123456789012345678901234
 
 // The hash assumes a little-endian architecture. Treating the hash results
 // as an array of uint64_t should enable conversion for big-endian implementations.
-const TestVectorData TestVector [] = 
+const TestVectorData TestVector [] =
 {
 	// seed = 0
 	{ metrohash64_1,      64, test_key_63, 0, "658F044F5C730E40" },
 	{ metrohash64_2,      64, test_key_63, 0, "073CAAB960623211" },
 	{ metrohash128_1,    128, test_key_63, 0, "ED9997ED9D0A8B0FF3F266399477788F" },
 	{ metrohash128_2,    128, test_key_63, 0, "7BBA6FE119CF35D45507EDF3505359AB" },
+#ifdef __x86_64__
 	{ metrohash128crc_1, 128, test_key_63, 0, "B329ED67831604D3DFAC4E4876D8262F" },
 	{ metrohash128crc_2, 128, test_key_63, 0, "0502A67E257BBD77206BBCA6BBEF2653" },
+#endif
 
 	// seed = 1
 	{ metrohash64_1,      64, test_key_63, 1, "AE49EBB0A856537B" },
 	{ metrohash64_2,      64, test_key_63, 1, "CF518E9CF58402C0" },
 	{ metrohash128_1,    128, test_key_63, 1, "DDA6BA67F7DE755EFDF6BEABECCFD1F4" },
 	{ metrohash128_2,    128, test_key_63, 1, "2DA6AF149A5CDBC12B09DB0846D69EF0" },
+#ifdef __x86_64__
 	{ metrohash128crc_1, 128, test_key_63, 1, "E8FAB51AF19F18A7B10D0A57D4276DF2" },
 	{ metrohash128crc_2, 128, test_key_63, 1, "2D54F87181A0CF64B02C50D95692BC19" },
+#endif
 };
 
 


### PR DESCRIPTION
Don't build/test CRC versions when building for non-x86 target platforms.

Signed-off-by: Lexi Bromfield <lexinadia@google.com>